### PR TITLE
Publish agents and map dao/daogrp @id

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Current differences from stock ASpace:
   * Removes trailing comma + whitespace from titles
   * Finding aid language and script default to English/Latin
   * Language of materials defaults to English/Latin
+  * Publishes agents unless audience="internal"
+  

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Current differences from stock ASpace:
   * Removes trailing comma + whitespace from titles
   * Finding aid language and script default to English/Latin
   * Language of materials defaults to English/Latin
-  * Publishes agents unless audience="internal"
-  
+  * Publishes agents unless `audience="internal"`
+  * Maps @id in `<dao>` and `<daogrp>` to map to `digital_object_id`. Note that in valid EAD, `<dao id="">` can't start with a number.

--- a/backend/model/lyr_ead_converter.rb
+++ b/backend/model/lyr_ead_converter.rb
@@ -57,6 +57,13 @@ class EADConverter < Converter
         :finding_aid_language => 'eng',
         :finding_aid_script => 'Latn'
       }
+
+      @namespace_mappings ||= {}
+      @node.attributes.select {|a| a =~ /^xmlns:/}.each do |k, v|
+        if v == 'http://www.w3.org/1999/xlink'
+          @namespace_mappings[:xlink] = k.sub("xmlns:", "")
+        end
+      end
     end
 
     ignore "titlepage"
@@ -933,16 +940,17 @@ class EADConverter < Converter
       end
 
 
+      # Change to use id attibute, else UUID.
       make :digital_object, {
-             :digital_object_id => SecureRandom.uuid,
+             :digital_object_id => att('id') || SecureRandom.uuid,
              :publish => att('audience') != 'internal',
-             :title => att('title')
+             :title => att('title', :xlink)
            } do |obj|
         obj.file_versions << {
-          :use_statement => att('role'),
-          :file_uri => att('href'),
-          :xlink_actuate_attribute => att('actuate'),
-          :xlink_show_attribute => att('show'),
+          :use_statement => att('role', :xlink),
+          :file_uri => att('href', :xlink),
+          :xlink_actuate_attribute => att('actuate', :xlink),
+          :xlink_show_attribute => att('show', :xlink),
           :publish => att('audience') != 'internal',
         }
         set ancestor(:instance), :digital_object, obj
@@ -973,8 +981,9 @@ class EADConverter < Converter
         }
       end
 
+      # Change to use id attibute for digital_object_id, else UUID.
       make :digital_object, {
-        :digital_object_id => SecureRandom.uuid,
+        :digital_object_id => att('id') || SecureRandom.uuid,
         :title => title,
         :publish => att('audience') != 'internal'
        } do |obj|

--- a/backend/model/lyr_ead_converter.rb
+++ b/backend/model/lyr_ead_converter.rb
@@ -1019,13 +1019,13 @@ class EADConverter < Converter
 
 
 
-  # Templates Section
+  # Templates Section: change default agent publish behavior.
 
   def make_corp_template(opts)
     return nil if inner_xml.strip.empty?
     make :agent_corporate_entity, {
       :agent_type => 'agent_corporate_entity',
-      :publish => att('audience') == 'external' ? true : false
+      :publish => att('audience') != 'internal'
     } do |corp|
       set ancestor(:resource, :archival_object), :linked_agents, {'ref' => corp.uri, 'role' => opts[:role], 'relator' => att('role')}
     end
@@ -1045,7 +1045,7 @@ class EADConverter < Converter
     return nil if inner_xml.strip.empty?
     make :agent_family, {
       :agent_type => 'agent_family',
-      :publish => att('audience') == 'external' ? true : false
+      :publish => att('audience') != 'internal'
     } do |family|
       set ancestor(:resource, :archival_object), :linked_agents, {'ref' => family.uri, 'role' => opts[:role], 'relator' => att('role')}
     end
@@ -1065,7 +1065,7 @@ class EADConverter < Converter
     return nil if inner_xml.strip.empty?
     make :agent_person, {
       :agent_type => 'agent_person',
-      :publish => att('audience') == 'external' ? true : false
+      :publish => att('audience') != 'internal'
     } do |person|
       set ancestor(:resource, :archival_object), :linked_agents, {'ref' => person.uri, 'role' => opts[:role], 'relator' => att('role')}
     end


### PR DESCRIPTION
Updates the following which seem like broadly desirable:
- Makes agents created through EAD public unless `audience="internal"`
- Maps @id in `<dao>` and <daogrp> to digital_object_id, else creates a UUID
- Fixes some xlink attribute issues to match core/XSD schema. 